### PR TITLE
No need to pass an object by reference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ php:
   - '5.5'
   - '5.6'
   - '7.0'
+  - '7.1'
+  - '7.2'
+  - '7.3'
 
 before_install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,11 @@
       "email": "james@jgrundner.com",
       "homepage": "http://jgrundner.com",
       "role": "Developer"
+    },
+    {
+      "name": "Sergey Gripinskiy",
+      "email": "web-architect@mail.ru",
+      "role": "Contributor"
     }
   ],
   "autoload": {

--- a/src/Traits/InvokePrivateMethodTrait.php
+++ b/src/Traits/InvokePrivateMethodTrait.php
@@ -13,13 +13,13 @@ trait InvokePrivateMethodTrait
     /**
      * Call protected/private method of a class.
      *
-     * @param object &$object Instantiated object that we will run method on.
+     * @param object $object Instantiated object that we will run method on.
      * @param string $methodName Method name to call
      * @param array $parameters Array of parameters to pass into method.
      *
      * @return mixed Method return.
      */
-    public function invokeMethod(&$object, $methodName, array $parameters = array())
+    public function invokeMethod($object, $methodName, array $parameters = array())
     {
         return self::invoke($object, $methodName, $parameters);
     }
@@ -27,13 +27,13 @@ trait InvokePrivateMethodTrait
     /**
      * Call protected/private method of a class statically.
      *
-     * @param $object
-     * @param $methodName
+     * @param object $object
+     * @param string $methodName
      * @param array $parameters
      *
      * @return mixed
      */
-    public static function invoke(&$object, $methodName, array $parameters = array())
+    public static function invoke($object, $methodName, array $parameters = array())
     {
 
         try {

--- a/tests/InvokePrivateMethodTest.php
+++ b/tests/InvokePrivateMethodTest.php
@@ -20,14 +20,6 @@ class InvokePrivateMethodTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-    }
-
-    /**
      * @covers \Jimigrunge\InvokePrivateMethods\InvokePrivateMethod::__construct
      */
     public function testInvokerCanBeCreated()
@@ -41,6 +33,14 @@ class InvokePrivateMethodTest extends \PHPUnit_Framework_TestCase
     public function testBadMethodCall()
     {
         $this->invoker->invokeMethod($this->dummyObject, 'myMissingFunction');
+    }
+
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testBadMethodCallWithoutObjectInVariable()
+    {
+        $this->invoker->invokeMethod(new DummyClass(), 'myMissingFunction');
     }
 
     /**
@@ -76,6 +76,42 @@ class InvokePrivateMethodTest extends \PHPUnit_Framework_TestCase
     public function testAccessPrivateMethodStaticWithParam()
     {
         $result = InvokePrivateMethod::invoke($this->dummyObject, 'myPrivateFunction', ['Jim']);
+        $this->assertEquals('Test Success Jim', trim($result));
+    }
+
+    /**
+     * @covers \Jimigrunge\InvokePrivateMethods\InvokePrivateMethod::invokeMethod
+     */
+    public function testAccessPrivateMethodWithoutObjectInVariableNoParam()
+    {
+        $result = $this->invoker->invokeMethod(new DummyClass(), 'myPrivateFunction');
+        $this->assertEquals('Test Success', trim($result));
+    }
+
+    /**
+     * @covers \Jimigrunge\InvokePrivateMethods\InvokePrivateMethod::invokeMethod
+     */
+    public function testAccessPrivateMethodWithoutObjectInVariableWithParam()
+    {
+        $result = $this->invoker->invokeMethod(new DummyClass(), 'myPrivateFunction', ['Jim']);
+        $this->assertEquals('Test Success Jim', trim($result));
+    }
+
+    /**
+     * @covers \Jimigrunge\InvokePrivateMethods\InvokePrivateMethod::invoke
+     */
+    public function testAccessPrivateMethodStaticWithoutObjectInVariableNoParam()
+    {
+        $result = InvokePrivateMethod::invoke(new DummyClass(), 'myPrivateFunction');
+        $this->assertEquals('Test Success', trim($result));
+    }
+
+    /**
+     * @covers \Jimigrunge\InvokePrivateMethods\InvokePrivateMethod::invoke
+     */
+    public function testAccessPrivateMethodStaticWithoutObjectInVariableWithParam()
+    {
+        $result = InvokePrivateMethod::invoke(new DummyClass(), 'myPrivateFunction', ['Jim']);
         $this->assertEquals('Test Success Jim', trim($result));
     }
 

--- a/tests/InvokePrivateMethodTraitTest.php
+++ b/tests/InvokePrivateMethodTraitTest.php
@@ -25,6 +25,14 @@ class InvokePrivateMethodTraitTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException BadMethodCallException
+     */
+    public function testBadMethodCallWithoutObjectInVariable()
+    {
+        $this->invokeMethod(new DummyClass(), 'myMissingFunction');
+    }
+
+    /**
      * @covers \Jimigrunge\InvokePrivateMethods\Traits\InvokePrivateMethodTrait::invokeMethod
      */
     public function testAccessPrivateMethodCallNoParam()
@@ -60,6 +68,45 @@ class InvokePrivateMethodTraitTest extends \PHPUnit_Framework_TestCase
     {
         // Can also be used statically
         $result = self::invoke($this->dummyObject, 'myPrivateFunction', ['Jim']);
+        $this->assertEquals('Test Success Jim', trim($result));
+    }
+
+    /**
+     * @covers \Jimigrunge\InvokePrivateMethods\Traits\InvokePrivateMethodTrait::invokeMethod
+     */
+    public function testAccessPrivateMethodCallWithoutObjectInVariableNoParam()
+    {
+        $result = $this->invokeMethod(new DummyClass(), 'myPrivateFunction');
+        $this->assertEquals('Test Success', trim($result));
+    }
+
+    /**
+     * @covers \Jimigrunge\InvokePrivateMethods\Traits\InvokePrivateMethodTrait::invokeMethod
+     */
+    public function testAccessPrivateMethodCallWithoutObjectInVariableWithParam()
+    {
+        // Call invoke method on private function
+        $result = $this->invokeMethod(new DummyClass(), 'myPrivateFunction', ['Jim']);
+        $this->assertEquals('Test Success Jim', trim($result));
+    }
+
+    /**
+     * @covers \Jimigrunge\InvokePrivateMethods\Traits\InvokePrivateMethodTrait::invoke
+     */
+    public function testAccessPrivateMethodStaticWithoutObjectInVariableNoParam()
+    {
+        // Can also be used statically
+        $result = self::invoke(new DummyClass(), 'myPrivateFunction');
+        $this->assertEquals('Test Success', trim($result));
+    }
+
+    /**
+     * @covers \Jimigrunge\InvokePrivateMethods\Traits\InvokePrivateMethodTrait::invoke
+     */
+    public function testAccessPrivateMethodStaticWithoutObjectInVariableWithParam()
+    {
+        // Can also be used statically
+        $result = self::invoke(new DummyClass(), 'myPrivateFunction', ['Jim']);
         $this->assertEquals('Test Success Jim', trim($result));
     }
 }


### PR DESCRIPTION
Excessive passing by reference is removed;
phpDoc is updated;
`InvokePrivateMethodTest::tearDown` is removed: does nothing and is not needed;